### PR TITLE
Add host response code in trx plugin info

### DIFF
--- a/lib/orbital/models/response.rb
+++ b/lib/orbital/models/response.rb
@@ -91,6 +91,12 @@ module Killbill #:nodoc:
       def gateway_error_code
         params_resp_code
       end
+
+      def to_transaction_info_plugin(transaction=nil)
+        t_info_plugin = super(transaction)
+        t_info_plugin.properties << create_plugin_property('processorResponse', params_host_resp_code)
+        t_info_plugin
+      end
     end
   end
 end

--- a/spec/orbital/remote/integration_spec.rb
+++ b/spec/orbital/remote/integration_spec.rb
@@ -19,6 +19,7 @@ shared_examples 'common_specs' do
     payment_response.status.should eq(:PROCESSED), payment_response.gateway_error
     payment_response.amount.should == @amount
     payment_response.transaction_type.should == :PURCHASE
+    find_value_from_properties(payment_response.properties, 'processorResponse').should == '100'
 
     responses = Killbill::Orbital::OrbitalResponse.all
     responses.size.should == 2
@@ -36,6 +37,7 @@ shared_examples 'common_specs' do
     payment_response.status.should eq(:PROCESSED), payment_response.gateway_error
     payment_response.amount.should == @amount
     payment_response.transaction_type.should == :PURCHASE
+    find_value_from_properties(payment_response.properties, 'processorResponse').should == '100'
 
     # Try a full refund
     refund_response = @plugin.refund_payment(@pm.kb_account_id, @kb_payment.id, @kb_payment.transactions[1].id, @pm.kb_payment_method_id, @amount, @currency, @properties, @call_context)
@@ -49,6 +51,7 @@ shared_examples 'common_specs' do
     payment_response.status.should eq(:PROCESSED), payment_response.gateway_error
     payment_response.amount.should == @amount
     payment_response.transaction_type.should == :AUTHORIZE
+    find_value_from_properties(payment_response.properties, 'processorResponse').should == '100'
 
     # Try multiple partial captures
     partial_capture_amount = BigDecimal.new('10')
@@ -77,6 +80,7 @@ shared_examples 'common_specs' do
     payment_response.status.should eq(:PROCESSED), payment_response.gateway_error
     payment_response.amount.should == @amount
     payment_response.transaction_type.should == :AUTHORIZE
+    find_value_from_properties(payment_response.properties, 'processorResponse').should == '100'
 
     payment_response = @plugin.void_payment(@pm.kb_account_id, @kb_payment.id, @kb_payment.transactions[1].id, @pm.kb_payment_method_id, @properties, @call_context)
     payment_response.status.should eq(:PROCESSED), payment_response.gateway_error
@@ -88,6 +92,7 @@ shared_examples 'common_specs' do
     payment_response.status.should eq(:PROCESSED), payment_response.gateway_error
     payment_response.amount.should == @amount
     payment_response.transaction_type.should == :AUTHORIZE
+    find_value_from_properties(payment_response.properties, 'processorResponse').should == '100'
 
     partial_capture_amount = BigDecimal.new('10')
     payment_response       = @plugin.capture_payment(@pm.kb_account_id, @kb_payment.id, @kb_payment.transactions[1].id, @pm.kb_payment_method_id, partial_capture_amount, @currency, @properties, @call_context)
@@ -98,6 +103,15 @@ shared_examples 'common_specs' do
     payment_response = @plugin.void_payment(@pm.kb_account_id, @kb_payment.id, @kb_payment.transactions[2].id, @pm.kb_payment_method_id, @properties, @call_context)
     payment_response.status.should eq(:PROCESSED), payment_response.gateway_error
     payment_response.transaction_type.should == :VOID
+  end
+
+  it 'should include host response code' do
+    # Sending a specific amount of 530 will trigger the Do Not Honor error.
+    payment_response = @plugin.authorize_payment(@pm.kb_account_id, @kb_payment.id, @kb_payment.transactions[0].id, @pm.kb_payment_method_id, BigDecimal.new('530'), @currency, @properties, @call_context)
+    payment_response.status.should eq(:ERROR), payment_response.gateway_error
+    payment_response.transaction_type.should == :AUTHORIZE
+    payment_response.amount.should be_nil
+    find_value_from_properties(payment_response.properties, 'processorResponse').should == '530'
   end
 end
 


### PR DESCRIPTION
@pierre Please review. This is for retries plugin to correctly extract processor response from Orbital