### PR TITLE
Override search_where_clause

### DIFF
--- a/lib/orbital/models/response.rb
+++ b/lib/orbital/models/response.rb
@@ -175,6 +175,18 @@ module Killbill #:nodoc:
         t_info_plugin.properties << create_plugin_property('mit_received_transaction_id', params_mit_received_transaction_id)
         t_info_plugin
       end
+
+      def self.search_where_clause(t, search_key)
+        where_clause = super(t, search_key)
+        
+        search_fields = Killbill::Plugin::ActiveMerchant.glob_config[:search_fields]
+        if search_fields && search_fields.is_a?(Array)
+          where_clauses = search_fields.map { |search_field| t[search_field.to_sym].eq(search_key) }
+          where_clause = where_clauses.reduce(:or)
+        end
+
+        return where_clause
+      end
     end
   end
 end

--- a/spec/orbital/response_spec.rb
+++ b/spec/orbital/response_spec.rb
@@ -61,7 +61,7 @@ describe Killbill::Orbital::OrbitalResponse do
         eos
       }
 
-      it 'should return the same where clause as ::Killbill::Plugin::ActiveMerchant::ActiveRecord::Response' do
+      it 'should return the where clause using the search_fields' do
         expect(subject).to eq("\"orbital_responses\".\"params_tx_ref_num\" = 'search_key'")
       end
     end

--- a/spec/orbital/response_spec.rb
+++ b/spec/orbital/response_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+describe Killbill::Orbital::OrbitalResponse do
+
+  include ::Killbill::Plugin::ActiveMerchant::RSpec
+
+  describe '.search_where_clause' do
+    let(:arel_table) { described_class.arel_table }
+    let(:search_key) { 'search_key' }
+
+    subject { described_class.search_where_clause(arel_table, search_key).to_sql }
+
+    before(:each) do
+      Dir.mktmpdir do |dir|
+        file = File.new(File.join(dir, 'orbital.yml'), 'w+')
+        file.write(configs)
+        file.close
+  
+        @plugin = build_plugin(::Killbill::Orbital::PaymentPlugin, 'orbital', File.dirname(file))
+
+        # Start the plugin here - since the config file will be deleted
+        @plugin.start_plugin
+      end
+    end
+
+    after(:each) do
+      @plugin.stop_plugin
+    end
+
+    context 'while search_fields is not configured' do
+      let(:configs) {
+        <<-eos
+:orbital:
+  :test: true
+# As defined by spec_helper.rb
+:database:
+  :adapter: 'sqlite3'
+  :database: 'test.db'
+        eos
+      }
+
+      it 'should return the same where clause as ::Killbill::Plugin::ActiveMerchant::ActiveRecord::Response' do
+        expected_search_where_clause = 
+          ::Killbill::Plugin::ActiveMerchant::ActiveRecord::Response.search_where_clause(arel_table, search_key).to_sql
+  
+        expect(subject).to eq(expected_search_where_clause)
+      end
+    end
+
+    context 'while search_fields is configured' do
+      let(:configs) {
+        <<-eos
+:orbital:
+  :test: true
+# As defined by spec_helper.rb
+:database:
+  :adapter: 'sqlite3'
+  :database: 'test.db'
+:search_fields:
+  - :params_tx_ref_num
+        eos
+      }
+
+      it 'should return the same where clause as ::Killbill::Plugin::ActiveMerchant::ActiveRecord::Response' do
+        expect(subject).to eq("\"orbital_responses\".\"params_tx_ref_num\" = 'search_key'")
+      end
+    end
+  end
+end


### PR DESCRIPTION
It will use the search_fields list if configured. Anyone can specify their own orbital.yml to search payments with the Orbital fields they want.

`:search_fields` must be an array of field symbols, otherwise nor `nil` will result the original super method be called.

There is no validation of the field list, an field does not exist in the response table would cause the SQL error.