### PR TITLE
Fix bug for inquiry payment for normal capture

### DIFF
--- a/lib/orbital/ext/active_merchant/active_merchant.rb
+++ b/lib/orbital/ext/active_merchant/active_merchant.rb
@@ -133,7 +133,7 @@ module ActiveMerchant
 
       # MFC - Mark For Capture or Force capture
       def capture(money, authorization, options = {})
-        commit(build_mark_for_capture_xml(money, authorization, options), :capture)
+        commit(build_mark_for_capture_xml(money, authorization, options), :capture, options[:trace_number])
       end
 
       def credit(money, creditcard, options= {})

--- a/spec/orbital/remote/shared_examples_for_payment_flow.rb
+++ b/spec/orbital/remote/shared_examples_for_payment_flow.rb
@@ -203,7 +203,7 @@ shared_examples 'payment_flow_spec' do
 
     # Force a transition to :UNDEFINED
     response, initial_auth = transition_last_response_to_UNDEFINED(2)
-    transaction_info_plugins = @plugin.get_payment_info(@pm.kb_account_id, @kb_payment.id,  [skip_gw_property], @call_context)
+    transaction_info_plugins = @plugin.get_payment_info(@pm.kb_account_id, @kb_payment.id,  [build_property('skip_gw', 'true')], @call_context)
     @plugin.send(:find_auth_order_id, transaction_info_plugins).should == payment_response.second_payment_reference_id
 
     fix_transaction(1)


### PR DESCRIPTION
cc @pierre for review. 

Use the actual retry for janitor flow on MarkForCapture because inquiry is not supported on MarkForCapture. 