### PR TITLE
Add index of params_tx_ref_num and kb_tenant_id on orbital_responses

### DIFF
--- a/db/ddl.sql
+++ b/db/ddl.sql
@@ -134,3 +134,4 @@ CREATE TABLE orbital_responses (
 ) /*! ENGINE=InnoDB CHARACTER SET utf8 COLLATE utf8_bin */;
 CREATE INDEX index_orbital_responses_kb_payment_id_kb_tenant_id ON orbital_responses(kb_payment_id, kb_tenant_id);
 CREATE INDEX index_orbital_responses_kb_payment_transaction_id_kb_tenant_id ON orbital_responses(kb_payment_transaction_id, kb_tenant_id);
+CREATE INDEX index_orbital_responses_params_tx_ref_num_kb_tenant_id ON orbital_responses(params_tx_ref_num, kb_tenant_id);

--- a/db/migrate/20181029172615_add_index_to_orbital_responses.rb
+++ b/db/migrate/20181029172615_add_index_to_orbital_responses.rb
@@ -1,0 +1,6 @@
+class AddIndexToOrbitalResponses < ActiveRecord::Migration
+
+  def change
+    add_index :orbital_responses, [:params_tx_ref_num, :kb_tenant_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,6 +1,6 @@
 require 'active_record'
 
-ActiveRecord::Schema.define(:version => 20140410153635) do
+ActiveRecord::Schema.define(:version => 20181029172615) do
   create_table "orbital_payment_methods", :force => true do |t|
     t.string   "kb_payment_method_id"      # NULL before Kill Bill knows about it
     t.string   "token"                     # orbital id
@@ -133,4 +133,5 @@ ActiveRecord::Schema.define(:version => 20140410153635) do
   end
 
   add_index(:orbital_responses, [:kb_payment_id, :kb_tenant_id])
+  add_index(:orbital_responses, [:params_tx_ref_num, :kb_tenant_id])
 end


### PR DESCRIPTION
It is required by the search on `params_tx_ref_num` and `kb_tenant_id` fields.