### PR TITLE
Override .max_nb_records

### DIFF
--- a/lib/orbital/models/response.rb
+++ b/lib/orbital/models/response.rb
@@ -6,6 +6,8 @@ module Killbill #:nodoc:
 
       has_one :orbital_transaction
 
+      scope :succeeded, -> { where(:success => true) }
+
       def self.from_response(api_call, kb_account_id, kb_payment_id, kb_payment_transaction_id, transaction_type, payment_processor_account_id, kb_tenant_id, response, extra_params = {}, model = ::Killbill::Orbital::OrbitalResponse)
         super(api_call,
               kb_account_id,
@@ -188,9 +190,14 @@ module Killbill #:nodoc:
         return where_clause
       end
 
-      # not needed, put a big number beyond the accurate limit (20k) here to make the pagination work
+      SIMPLE_PAGINATION_THRESHOLD = 20000
+
       def self.max_nb_records
-        20001
+        if self.succeeded.limit(1).offset(SIMPLE_PAGINATION_THRESHOLD).nil?
+          self.succeeded.count
+        else
+          SIMPLE_PAGINATION_THRESHOLD + 1
+        end
       end
     end
   end

--- a/lib/orbital/models/response.rb
+++ b/lib/orbital/models/response.rb
@@ -187,6 +187,11 @@ module Killbill #:nodoc:
 
         return where_clause
       end
+
+      # not needed, put a big number beyond the accurate limit (20k) here to make the pagination work
+      def self.max_nb_records
+        20001
+      end
     end
   end
 end

--- a/spec/orbital/response_spec.rb
+++ b/spec/orbital/response_spec.rb
@@ -66,4 +66,12 @@ describe Killbill::Orbital::OrbitalResponse do
       end
     end
   end
+
+  describe '.max_nb_records' do
+    subject { described_class.max_nb_records }
+
+    it 'should be equal to a fixed number 20001' do
+      expect(subject).to eq(20001)
+    end
+  end
 end

--- a/spec/orbital/response_spec.rb
+++ b/spec/orbital/response_spec.rb
@@ -68,10 +68,27 @@ describe Killbill::Orbital::OrbitalResponse do
   end
 
   describe '.max_nb_records' do
+    before(:each) do
+      described_class.stub_chain(:succeeded, :limit, :offset, :nil?).and_return(target_response_nil?)
+    end
+
     subject { described_class.max_nb_records }
 
-    it 'should be equal to a fixed number 20001' do
-      expect(subject).to eq(20001)
+    context 'when the target response exists' do
+      let(:target_response_nil?) { false }
+
+      it { should eq(described_class::SIMPLE_PAGINATION_THRESHOLD + 1) }
+    end
+
+    context 'when the target response does not exist' do
+      let(:target_response_nil?) { true }
+      let(:success_response_count) { 123 }
+
+      before(:all) do
+        described_class.stub_chain(:succeeded, :count).and_return(success_response_count)
+      end
+
+      it { should eq(success_response_count) }
     end
   end
 end


### PR DESCRIPTION
Improve the pagination performance to https://github.com/killbill/killbill-plugin-framework-ruby/issues/67, return 20001 when records are more than 20k.